### PR TITLE
Order by attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mdxpy/__pycache__/__init__.cpython-37.pyc
+mdxpy/__pycache__/mdx.cpython-37.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mdxpy/__pycache__/__init__.cpython-37.pyc
 mdxpy/__pycache__/mdx.cpython-37.pyc
+*.pyc

--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -583,8 +583,8 @@ class OrderByAttributeValueHierarchySet(MdxHierarchySet):
         super(OrderByAttributeValueHierarchySet, self).__init__(underlying_hierarchy_set.dimension,
                                                            underlying_hierarchy_set.hierarchy)
         self.underlying_hierarchy_set = underlying_hierarchy_set
-        self.attribute_name = attribute_name
-        self.flag = flag
+        self.attribute_name = normalize(attribute_name)
+        self.flag = normalize(flag)
 
     def to_mdx(self) -> str:
         return f"{{ORDER({self.underlying_hierarchy_set.to_mdx()},[{self.underlying_hierarchy_set.dimension}].[{self.underlying_hierarchy_set.hierarchy}].CURRENTMEMBER.PROPERTIES(\"{self.attribute_name}\"), {self.flag})}}"

--- a/test.py
+++ b/test.py
@@ -149,7 +149,7 @@ class Test(unittest.TestCase):
     def test_mdx_hierarchy_set_tm1_subset_to_set(self):
         hierarchy_set = MdxHierarchySet.tm1_subset_to_set("Dimension", "Hierarchy", "Default")
         self.assertEqual(
-            "{TM1SUBSETTOSET([DIMENSION].[HIERARCHY],'Default')}",
+            '{TM1SUBSETTOSET([DIMENSION].[HIERARCHY],"Default")}',
             hierarchy_set.to_mdx())
 
     def test_mdx_hierarchy_set_all_consolidations(self):
@@ -271,13 +271,13 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             hierarchy_set.to_mdx(),
-            "{FILTER({[DIMENSION].[HIERARCHY].MEMBERS},[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])='Value1')}")
+            '{FILTER({[DIMENSION].[HIERARCHY].MEMBERS},[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])="Value1")}')
 
     def test_mdx_filter_by_attribute_single_string(self):
         hierarchy_set = MdxHierarchySet.tm1_subset_all("Dimension").filter_by_attribute("Attribute1", ["Value1"])
         self.assertEqual(
             "{FILTER({TM1SUBSETALL([DIMENSION].[DIMENSION])},"
-            "[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])='Value1')}",
+            '[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])="Value1")}',
             hierarchy_set.to_mdx())
 
     def test_mdx_filter_by_attribute_single_numeric(self):
@@ -293,10 +293,10 @@ class Test(unittest.TestCase):
                                                                                         ["Value1", 1, 2.0])
 
         self.assertEqual(
-            "{FILTER({TM1SUBSETALL([DIMENSION].[DIMENSION])},"
-            "[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])='Value1' OR "
-            "[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])=1 OR "
-            "[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])=2.0)}",
+            '{FILTER({TM1SUBSETALL([DIMENSION].[DIMENSION])},'
+            '[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])="Value1" OR '
+            '[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])=1 OR '
+            '[}ELEMENTATTRIBUTES_DIMENSION].([}ELEMENTATTRIBUTES_DIMENSION].[Attribute1])=2.0)}',
             hierarchy_set.to_mdx())
 
     def test_mdx_hierarchy_set_filter_by_wildcard(self):
@@ -434,6 +434,16 @@ class Test(unittest.TestCase):
         self.assertEqual(
             "{ORDER({[DIMENSION1].[HIERARCHY1].MEMBERS},"
             "[CUBE].([DIMENSION2].[HIERARCHY2].[ELEMENTA],[DIMENSION3].[HIERARCHY3].[ELEMENTB]))}",
+            hierarchy_set.to_mdx())
+
+    def test_mdx_hierarchy_set_order_by_attribute(self):
+        hierarchy_set = MdxHierarchySet.all_members("Dimension1", "Hierarchy1").order_by_attribute(
+            attribute_name="Attribute1",
+            flag = 'asc')
+
+        self.assertEqual(
+            '{ORDER({[DIMENSION1].[HIERARCHY1].MEMBERS},'
+            '[DIMENSION1].[HIERARCHY1].CURRENTMEMBER.PROPERTIES("ATTRIBUTE1"), ASC)}',
             hierarchy_set.to_mdx())
 
     def test_mdx_hierarchy_set_generate_attribute_to_member(self):


### PR DESCRIPTION
First off, thank you for putting this together and providing on github! I had some minor tweaks that I think make sense for most users.

Largely, added two new functions. 
to_clipboard() will print the mdx statement, as well as put onto the users clipboard. In my case, using this library in Jupyter, I can execute the cell, and have the mdx already on my clipboard to be input into a TI process.
order_by_attribute() in MdxHierarchySet does as the name implies. The user can order within the member's dimension based on an attribute. An optional flag arg will allow the user to set the order preference, will default to BASC otherwise.

Quality of life improvements
Some functions returned a string that was wrapped in single quotes. Single quotes have to be escaped if used in a TI function, making it a bit frustrating if needed to be done. Single quotes are also still syntactically correct for MDX, so I replaced where found. Test cases were updated as well to fit this change.
Added an operator arg to filter_by_attribute() in MdxHierarchySet. The user will have the flexibility to specify the operator, or go with '=' by default and omitting the arg.

Unit tests have been updated to fit these updates. 

Once again, thank you for putting this out there! 