### PR TITLE
Made arg for hierarchy optional in tm1_subset_to_set()

### DIFF
--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -177,8 +177,8 @@ class MdxHierarchySet:
         return AllMembersHierarchySet(dimension, hierarchy)
 
     @staticmethod
-    def tm1_subset_to_set(dimension: str, hierarchy: str, subset: str) -> 'MdxHierarchySet':
-        return Tm1SubsetToSetHierarchySet(dimension, hierarchy, subset)
+    def tm1_subset_to_set(*args: str, dimension: str = None, hierarchy: str = None, subset: str = None) -> 'MdxHierarchySet':
+        return Tm1SubsetToSetHierarchySet(args, dimension, hierarchy, subset)
 
     @staticmethod
     def all_consolidations(dimension: str, hierarchy: str = None) -> 'MdxHierarchySet':
@@ -482,7 +482,27 @@ class DescendantsHierarchySet(MdxHierarchySet):
 
 
 class Tm1SubsetToSetHierarchySet(MdxHierarchySet):
-    def __init__(self, dimension: str, hierarchy: str, subset: str):
+    def __init__(self, args: str, dimension: str, hierarchy: str, subset: str):
+
+        error_message = ("Valid arguments are (\"dimension_name\", subset = \"subset_name\"), " + 
+                    "(\"dimension_name\", \"subset_name\"), (\"dimension_name\", \"hierarchy_name\", " + 
+                    "\"subset_name\"), or named args with or without a hierarchy specified. ")
+
+        if len(args) > 0:
+            if len(args) == 1:
+                dimension, subset = args[0], subset
+            elif len(args) == 2:
+                dimension, subset = args[0], args[1]
+            elif len(args) == 3:
+                dimension, hierarchy, subset = args[0], args[1], args[2]
+            else:
+                raise ValueError(error_message)
+
+        hierarchy = hierarchy if hierarchy else dimension
+
+        if None in (dimension, hierarchy, subset):
+            raise ValueError(f"{error_message} Current argument values are dimension = {dimension}, hierarchy = {hierarchy}, subset = {subset}")
+
         super(Tm1SubsetToSetHierarchySet, self).__init__(dimension, hierarchy)
         self.subset = subset
 

--- a/test.py
+++ b/test.py
@@ -147,8 +147,32 @@ class Test(unittest.TestCase):
             "{[DIMENSION].[HIERARCHY].MEMBERS}",
             hierarchy_set.to_mdx())
 
-    def test_mdx_hierarchy_set_tm1_subset_to_set(self):
+    def test_mdx_hierarchy_set_tm1_subset_to_set_three_args(self):
         hierarchy_set = MdxHierarchySet.tm1_subset_to_set("Dimension", "Hierarchy", "Default")
+        self.assertEqual(
+            '{TM1SUBSETTOSET([DIMENSION].[HIERARCHY],"Default")}',
+            hierarchy_set.to_mdx())
+
+    def test_mdx_hierarchy_set_tm1_subset_to_set_two_args(self):
+        hierarchy_set = MdxHierarchySet.tm1_subset_to_set("Dimension", "Default")
+        self.assertEqual(
+            '{TM1SUBSETTOSET([DIMENSION].[DIMENSION],"Default")}',
+            hierarchy_set.to_mdx())
+
+    def test_mdx_hierarchy_set_tm1_subset_to_set_one_args_subset_named(self):
+        hierarchy_set = MdxHierarchySet.tm1_subset_to_set("Dimension", subset = "Default")
+        self.assertEqual(
+            '{TM1SUBSETTOSET([DIMENSION].[DIMENSION],"Default")}',
+            hierarchy_set.to_mdx())
+
+    def test_mdx_hierarchy_set_tm1_subset_to_set_two_named_args(self):
+        hierarchy_set = MdxHierarchySet.tm1_subset_to_set(dimension="Dimension", subset="Default")
+        self.assertEqual(
+            '{TM1SUBSETTOSET([DIMENSION].[DIMENSION],"Default")}',
+            hierarchy_set.to_mdx())
+
+    def test_mdx_hierarchy_set_tm1_subset_to_set_three_named_args(self):
+        hierarchy_set = MdxHierarchySet.tm1_subset_to_set(dimension="Dimension", hierarchy="Hierarchy", subset="Default")
         self.assertEqual(
             '{TM1SUBSETTOSET([DIMENSION].[HIERARCHY],"Default")}',
             hierarchy_set.to_mdx())


### PR DESCRIPTION
Similar to the Member.of() function, provided various options for providing args to tm1_subset_to_set. All args may be provided via their position, or named. This way, hierarchy will defualt to the dim name, much like the other functions.
Valid arguments are
("dimension_name", subset = "subset_name"),
("dimension_name", "subset_name"),
("dimension_name", "hierarchy_name","subset_name"),
or named args with or without a hierarchy specified.
Tests updated appropriately.