### PR TITLE
Add mdx hierarchy sets to mdx hierarchy set

### DIFF
--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -211,6 +211,10 @@ class MdxHierarchySet:
         return ElementsHierarchySet(*members)
 
     @staticmethod
+    def sets(sets: List['MdxHierarchySet']) -> 'MdxHierarchySet':
+        return SetsHierarchySet(*sets)
+
+    @staticmethod
     def parent(member: Union[str, Member]) -> 'MdxHierarchySet':
         if isinstance(member, str):
             member = Member.of(member)
@@ -378,6 +382,18 @@ class ElementsHierarchySet(MdxHierarchySet):
 
     def to_mdx(self) -> str:
         return f"{{{','.join(member.unique_name for member in self.members)}}}"
+
+class SetsHierarchySet(MdxHierarchySet):
+
+    def __init__(self, *sets: MdxHierarchySet):
+        if not sets:
+            raise RuntimeError('sets must not be empty')
+
+        super(SetsHierarchySet, self).__init__(sets[0].dimension, sets[0].hierarchy)
+        self.sets = sets
+
+    def to_mdx(self) -> str:
+        return f"{{{','.join(set_.to_mdx() for set_ in self.sets)}}}"
 
 
 class ParentHierarchySet(MdxHierarchySet):

--- a/test.py
+++ b/test.py
@@ -188,8 +188,8 @@ class Test(unittest.TestCase):
             MdxHierarchySet.member(Member.of("Dimension", "element2")).tm1_drill_down_member()
         ])
         self.assertEqual(
-            "{{[DIMENSION].[DIMENSION].[ELEMENT1].CHILDREN}"
-            ",{TM1DRILLDOWNMEMBER({[DIMENSION].[DIMENSION].[ELEMENT2]}, "
+            "{{[DIMENSION].[DIMENSION].[ELEMENT1].CHILDREN},"
+            "{TM1DRILLDOWNMEMBER({[DIMENSION].[DIMENSION].[ELEMENT2]}, "
             "ALL, RECURSIVE)}}",
             hierarchy_set.to_mdx())
 

--- a/test.py
+++ b/test.py
@@ -182,6 +182,17 @@ class Test(unittest.TestCase):
             "{[DIMENSION].[DIMENSION].[ELEMENT1],[DIMENSION].[DIMENSION].[ELEMENT2]}",
             hierarchy_set.to_mdx())
 
+    def test_mdx_hierarchy_set_sets(self):
+        hierarchy_set = MdxHierarchySet.sets([
+            MdxHierarchySet.children(Member.of("Dimension", "element1")),
+            MdxHierarchySet.member(Member.of("Dimension", "element2")).tm1_drill_down_member()
+        ])
+        self.assertEqual(
+            "{{[DIMENSION].[DIMENSION].[ELEMENT1].CHILDREN}"
+            ",{TM1DRILLDOWNMEMBER({[DIMENSION].[DIMENSION].[ELEMENT2]}, "
+            "ALL, RECURSIVE)}}",
+            hierarchy_set.to_mdx())
+
     def test_mdx_hierarchy_set_parent(self):
         hierarchy_set = MdxHierarchySet.parent(Member.of("Dimension", "Element"))
 


### PR DESCRIPTION
Hi again! I ran into an issue while working on a project that this should address. Simply, this will allow the user to add independent MdxHierarchySets to a single MdxHierarchySet object. 

- The MDX will be wrapped and comma separated nicely for that one dimension across unique sets for one dimension. 

- The user can continue to manipulate the returns of those sets, with the functions available to MdxHierarchySet  class, and appropriately wrapped when printed to MDX. 

- Lastly, the single resulting MdxHierarchySet  object can be added to the MdxBuilder.add_hierarchy_set functions with all the resulting statements.