### PR TITLE
Make `MdxSet` useable in `MdxBuilder`

### DIFF
--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -1,7 +1,7 @@
 import os
 from abc import abstractmethod
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Iterable
 
 ELEMENT_ATTRIBUTE_PREFIX = "}ELEMENTATTRIBUTES_"
 
@@ -185,6 +185,10 @@ class MdxSet:
     def unions(sets: List['MdxSet'], allow_duplicates: bool = False) -> 'MdxSet':
         return MultiUnionSet(sets, allow_duplicates)
 
+    @staticmethod
+    def tuples(tuples: Iterable['MdxTuple']) -> 'MdxSet':
+        return TuplesSet(tuples)
+
 
 class CrossJoinMdxSet(MdxSet):
     def __init__(self, sets: List['MdxSet']):
@@ -194,6 +198,14 @@ class CrossJoinMdxSet(MdxSet):
 
     def to_mdx(self) -> str:
         return f"{{{' * '.join(set_.to_mdx() for set_ in self.sets)}}}"
+
+
+class TuplesSet(MdxSet):
+    def __init__(self, tuples: Iterable[MdxTuple]):
+        self.tuples = tuples
+
+    def to_mdx(self) -> str:
+        return f"{{ {','.join(tupl.to_mdx() for tupl in self.tuples)} }}"
 
 
 class MultiUnionSet(MdxSet):
@@ -844,8 +856,8 @@ class GenerateAttributeToMemberSet(MdxHierarchySet):
 
 class MdxAxis:
     def __init__(self):
-        self.tuples = list()
-        self.dim_sets = list()
+        self.tuples: List[MdxTuple] = list()
+        self.dim_sets: List[MdxSet] = list()
         self.non_empty = False
 
     @staticmethod
@@ -858,13 +870,14 @@ class MdxAxis:
 
         self.tuples.append(mdx_tuple)
 
-    def add_dim_set(self, mdx_hierarchy_set: MdxHierarchySet):
+    def add_set(self, mdx_set: MdxSet):
         if bool(self.tuples):
             raise ValueError("Can not add set to axis that contains tuples")
-        if not isinstance(mdx_hierarchy_set, MdxHierarchySet):
+
+        if not isinstance(mdx_set, MdxSet):
             raise ValueError("Can not add MDX Tuples to axis using set method")
 
-        self.dim_sets.append(mdx_hierarchy_set)
+        self.dim_sets.append(mdx_set)
 
     def is_empty(self) -> bool:
         return not self.dim_sets and not self.tuples
@@ -943,11 +956,20 @@ class MdxBuilder:
     def add_hierarchy_set_to_column_axis(self, mdx_hierarchy_set: MdxHierarchySet) -> 'MdxBuilder':
         return self.add_hierarchy_set_to_axis(0, mdx_hierarchy_set)
 
+    def add_set_to_row_axis(self, mdx_set: MdxSet) -> 'MdxBuilder':
+        return self.add_set_to_axis(1, mdx_set)
+
+    def add_set_to_column_axis(self, mdx_set: MdxSet) -> 'MdxBuilder':
+        return self.add_set_to_axis(0, mdx_set)
+
     def add_hierarchy_set_to_axis(self, axis: int, mdx_hierarchy_set: MdxHierarchySet) -> 'MdxBuilder':
+        return self.add_set_to_axis(axis, mdx_hierarchy_set)
+
+    def add_set_to_axis(self, axis: int, mdx_set: MdxSet) -> 'MdxBuilder':
         if axis not in self.axes:
             self.axes[axis] = MdxAxis.empty()
 
-        self.axes[axis].add_dim_set(mdx_hierarchy_set)
+        self.axes[axis].add_set(mdx_set)
         return self
 
     def add_empty_set_to_axis(self, axis: int):

--- a/test.py
+++ b/test.py
@@ -176,8 +176,8 @@ class Test(unittest.TestCase):
             "{[dimension].[dimension].[element1],[dimension].[dimension].[element2]}",
             hierarchy_set.to_mdx())
 
-    def test_mdx_hierarchy_set_unions_no_duplicates(self):
-        hierarchy_set = MdxHierarchySet.unions([
+    def test_mdx_set_unions_no_duplicates(self):
+        hierarchy_set = MdxSet.unions([
             MdxHierarchySet.children(Member.of("Dimension", "element1")),
             MdxHierarchySet.member(Member.of("Dimension", "element2")),
             MdxHierarchySet.member(Member.of("Dimension", "element3"))
@@ -189,8 +189,8 @@ class Test(unittest.TestCase):
             " + {[dimension].[dimension].[element3]}}",
             hierarchy_set.to_mdx())
 
-    def test_mdx_hierarchy_set_unions_allow_duplicates(self):
-        hierarchy_set = MdxHierarchySet.unions([
+    def test_mdx_set_unions_allow_duplicates(self):
+        hierarchy_set = MdxSet.unions([
             MdxHierarchySet.children(Member.of("Dimension", "element1")),
             MdxHierarchySet.member(Member.of("Dimension", "element2")),
             MdxHierarchySet.member(Member.of("Dimension", "element3"))
@@ -202,7 +202,7 @@ class Test(unittest.TestCase):
             "{[dimension].[dimension].[element3]}}",
             hierarchy_set.to_mdx())
 
-    def test_mdx_hierarchy_set_cross_joins(self):
+    def test_mdx_set_cross_joins(self):
         mdx_set = MdxSet.cross_joins([
             MdxHierarchySet.children(Member.of("Dimension", "element1")),
             MdxHierarchySet.member(Member.of("Dimension", "element2")),
@@ -215,8 +215,18 @@ class Test(unittest.TestCase):
             " * {[dimension].[dimension].[element3]}}",
             mdx_set.to_mdx())
 
-    def test_union_cross_join_sets(self):
-        pass
+    def test_mdx_set_tuples(self):
+        mdx_set = MdxSet.tuples([
+            MdxTuple([Member.of("dimension1", "element1"), Member.of("dimension2", "element3")]),
+            MdxTuple([Member.of("dimension1", "element2"), Member.of("dimension2", "element2")]),
+            MdxTuple([Member.of("dimension1", "element3"), Member.of("dimension2", "element1")])
+        ])
+
+        self.assertEqual(
+            "{ ([dimension1].[dimension1].[element1],[dimension2].[dimension2].[element3]),"
+            "([dimension1].[dimension1].[element2],[dimension2].[dimension2].[element2])," 
+            "([dimension1].[dimension1].[element3],[dimension2].[dimension2].[element1]) }",
+            mdx_set.to_mdx())
 
     def test_mdx_hierarchy_set_parent(self):
         hierarchy_set = MdxHierarchySet.parent(Member.of("Dimension", "Element"))


### PR DESCRIPTION
introduce `MdxSet.tuples` function:

```
tuple_set = MdxSet.tuples([
    MdxTuple.of(Member.of("d3", "e01"), Member.of("d4", "e02")),
    MdxTuple.of(Member.of("d3", "e03"), Member.of("d4", "e01")),
    MdxTuple.of(Member.of("d3", "e02"), Member.of("d4", "e03")),
])

query = MdxBuilder.from_cube("c4")
query.add_set_to_axis(0, tuple_set)

print(query.to_mdx())
```

```
SELECT
{ ([d3].[d3].[e01],[d4].[d4].[e02]),([d3].[d3].[e03],[d4].[d4].[e01]),([d3].[d3].[e02],[d4].[d4].[e03]) } ON 0
FROM [c4]
```