### PR TITLE
Feature/dimension properties final

### DIFF
--- a/mdxpy/__init__.py
+++ b/mdxpy/__init__.py
@@ -1,2 +1,2 @@
 from mdxpy.mdx import Member, CalculatedMember, MdxBuilder, MdxTuple, MdxHierarchySet, normalize, MdxSet, ElementType, \
-    Order, MdxPropertiesTuple, SetAttribute, MdxLevelExpression
+    Order, MdxPropertiesTuple, DimensionProperty, MdxLevelExpression

--- a/mdxpy/__init__.py
+++ b/mdxpy/__init__.py
@@ -1,2 +1,2 @@
 from mdxpy.mdx import Member, CalculatedMember, MdxBuilder, MdxTuple, MdxHierarchySet, normalize, MdxSet, ElementType, \
-    Order, MdxLevelExpression
+    Order, MdxPropertiesTuple, SetAttribute, MdxLevelExpression

--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -130,34 +130,25 @@ class Member:
         return hash(self.unique_name)
 
 
-class DimensionProperty:
+class DimensionProperty(Member):
     SHORT_NOTATION = False
 
-    def __init__(self, dimension: str, hierarchy: str, element: str):
-        self.dimension = dimension
-        self.hierarchy = hierarchy
-        self.element = element
-        self.unique_name = self.build_unique_name(dimension, hierarchy, element)
-
-    @classmethod
-    def build_unique_name(cls, dimension, hierarchy, element) -> str:
-        if cls.SHORT_NOTATION and dimension == hierarchy:
-            return f"[{normalize(dimension)}].[{normalize(element)}]"
-        return f"[{normalize(dimension)}].[{normalize(hierarchy)}].[{normalize(element)}]"
+    def __init__(self, dimension: str, hierarchy: str, attribute: str):
+        super(DimensionProperty, self).__init__(dimension, hierarchy, attribute)
 
     @staticmethod
     def from_unique_name(unique_name: str) -> 'DimensionProperty':
-        dimension = DimensionProperty.dimension_name_from_unique_name(unique_name)
-        element = DimensionProperty.element_name_from_unique_name(unique_name)
+        dimension = Member.dimension_name_from_unique_name(unique_name)
+        attribute = Member.element_name_from_unique_name(unique_name)
         if unique_name.count("].[") == 1:
-            return DimensionProperty(dimension, dimension, element)
+            return DimensionProperty(dimension, dimension, attribute)
 
         elif unique_name.count("].[") == 2:
-            hierarchy = DimensionProperty.hierarchy_name_from_unique_name(unique_name)
-            return DimensionProperty(dimension, hierarchy, element)
+            hierarchy = Member.hierarchy_name_from_unique_name(unique_name)
+            return DimensionProperty(dimension, hierarchy, attribute)
 
         else:
-            raise ValueError(f"Argument '{unique_name}' must be a valid SetAttribute unique name")
+            raise ValueError(f"Argument '{unique_name}' must be a valid DimensionProperty unique name")
 
     @staticmethod
     def of(*args: str) -> 'DimensionProperty':
@@ -170,24 +161,6 @@ class DimensionProperty:
             return DimensionProperty(*args)
         else:
             raise ValueError("method takes either one, two or three str arguments")
-
-    @staticmethod
-    def dimension_name_from_unique_name(element_unique_name: str) -> str:
-        return element_unique_name[1:element_unique_name.find('].[')]
-
-    @staticmethod
-    def hierarchy_name_from_unique_name(element_unique_name: str) -> str:
-        return element_unique_name[element_unique_name.find('].[') + 3:element_unique_name.rfind('].[')]
-
-    @staticmethod
-    def element_name_from_unique_name(element_unique_name: str) -> str:
-        return element_unique_name[element_unique_name.rfind('].[') + 3:-1]
-
-    def __eq__(self, other) -> bool:
-        return self.unique_name == other.unique_name
-
-    def __hash__(self):
-        return hash(self.unique_name)
 
 
 class CalculatedMember(Member):
@@ -1232,4 +1205,3 @@ class MdxBuilder:
         command = 'echo | set /p nul="' + mdx + '"| clip'
         os.system(command)
         print(mdx)
-

--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -130,6 +130,66 @@ class Member:
         return hash(self.unique_name)
 
 
+class SetAttribute:
+    SHORT_NOTATION = False
+
+    def __init__(self, dimension: str, hierarchy: str, element: str):
+        self.dimension = dimension
+        self.hierarchy = hierarchy
+        self.element = element
+        self.unique_name = self.build_unique_name(dimension, hierarchy, element)
+
+    @classmethod
+    def build_unique_name(cls, dimension, hierarchy, element) -> str:
+        if cls.SHORT_NOTATION and dimension == hierarchy:
+            return f"[{normalize(dimension)}].[{normalize(element)}]"
+        return f"[{normalize(dimension)}].[{normalize(hierarchy)}].[{normalize(element)}]"
+
+    @staticmethod
+    def from_unique_name(unique_name: str) -> 'SetAttribute':
+        dimension = SetAttribute.dimension_name_from_unique_name(unique_name)
+        element = SetAttribute.element_name_from_unique_name(unique_name)
+        if unique_name.count("].[") == 1:
+            return SetAttribute(dimension, dimension, element)
+
+        elif unique_name.count("].[") == 2:
+            hierarchy = SetAttribute.hierarchy_name_from_unique_name(unique_name)
+            return SetAttribute(dimension, hierarchy, element)
+
+        else:
+            raise ValueError(f"Argument '{unique_name}' must be a valid SetAttribute unique name")
+
+    @staticmethod
+    def of(*args: str) -> 'SetAttribute':
+        # case: '[dim].[elem]'
+        if len(args) == 1:
+            return SetAttribute.from_unique_name(args[0])
+        elif len(args) == 2:
+            return SetAttribute(args[0], args[0], args[1])
+        elif len(args) == 3:
+            return SetAttribute(*args)
+        else:
+            raise ValueError("method takes either one, two or three str arguments")
+
+    @staticmethod
+    def dimension_name_from_unique_name(element_unique_name: str) -> str:
+        return element_unique_name[1:element_unique_name.find('].[')]
+
+    @staticmethod
+    def hierarchy_name_from_unique_name(element_unique_name: str) -> str:
+        return element_unique_name[element_unique_name.find('].[') + 3:element_unique_name.rfind('].[')]
+
+    @staticmethod
+    def element_name_from_unique_name(element_unique_name: str) -> str:
+        return element_unique_name[element_unique_name.rfind('].[') + 3:-1]
+
+    def __eq__(self, other) -> bool:
+        return self.unique_name == other.unique_name
+
+    def __hash__(self):
+        return hash(self.unique_name)
+
+
 class CalculatedMember(Member):
     def __init__(self, dimension: str, hierarchy: str, element: str, calculation: str):
         super(CalculatedMember, self).__init__(dimension, hierarchy, element)
@@ -243,6 +303,39 @@ class MdxTuple:
 
     def to_mdx(self) -> str:
         return f"({','.join(member.unique_name for member in self.members)})"
+
+    def __len__(self):
+        return len(self.members)
+
+
+class MdxPropertiesTuple:
+
+    def __init__(self, members):
+        self.members = list(members)
+
+    @staticmethod
+    def of(*args: Union[str, SetAttribute]) -> 'MdxPropertiesTuple':
+        # handle unique element names
+        members = [SetAttribute.of(member)
+                   if isinstance(member, str) else member
+                   for member in args]
+        mdx_tuple = MdxPropertiesTuple(members)
+        return mdx_tuple
+
+    @staticmethod
+    def empty() -> 'MdxPropertiesTuple':
+        return MdxPropertiesTuple.of()
+
+    def add_member(self, member: Union[str, SetAttribute]):
+        if isinstance(member, str):
+            member = SetAttribute.of(member)
+        self.members.append(member)
+
+    def is_empty(self) -> bool:
+        return not self.members
+
+    def to_mdx(self) -> str:
+        return f"{','.join(member.unique_name for member in self.members)}"
 
     def __len__(self):
         return len(self.members)
@@ -989,6 +1082,7 @@ class MdxBuilder:
         self.cube = normalize(cube)
         self.axes = {0: MdxAxis.empty()}
         self._where = MdxTuple.empty()
+        self._properties = MdxPropertiesTuple.empty()
         self.calculated_members = list()
         self._tm1_ignore_bad_tuples = False
 
@@ -1069,6 +1163,10 @@ class MdxBuilder:
         self._where.add_member(member)
         return self
 
+    def add_member_to_properties(self, member: Union[str, SetAttribute]) -> 'MdxBuilder':
+        self._properties.add_member(member)
+        return self
+
     def where(self, *args: Union[str, Member]) -> 'MdxBuilder':
         for member in args:
             if isinstance(member, str):
@@ -1076,6 +1174,15 @@ class MdxBuilder:
             if not isinstance(member, Member):
                 raise ValueError(f"Argument '{member}' must be of type str or Member")
             self.add_member_to_where(member)
+        return self
+
+    def properties(self, *args: Union[str, SetAttribute]) -> 'MdxBuilder':
+        for member in args:
+            if isinstance(member, str):
+                member = SetAttribute.of(member)
+            if not isinstance(member, SetAttribute):
+                raise ValueError(f"Argument '{member}' must be of type str or Member")
+            self.add_member_to_properties(member)
         return self
 
     def to_mdx(self) -> str:
@@ -1091,7 +1198,9 @@ class MdxBuilder:
 
         mdx_where = "\r\nWHERE " + self._where.to_mdx() if not self._where.is_empty() else ""
 
-        return f"""{mdx_with if self.calculated_members else ""}SELECT\r\n{mdx_axes}\r\nFROM [{self.cube}]{mdx_where}"""
+        mdx_properties = "\r\nDIMENSION PROPERTIES " + self._properties.to_mdx() if not self._properties.is_empty() else ""
+
+        return f"""{mdx_with if self.calculated_members else ""}SELECT\r\n{mdx_axes}\r\nFROM [{self.cube}]{mdx_where}{mdx_properties}"""
 
     def to_clipboard(self):
         mdx = self.to_mdx()

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ import unittest
 
 import pytest
 
-from mdxpy import SetAttribute, Member, MdxTuple, MdxHierarchySet, normalize, MdxBuilder, CalculatedMember, MdxSet, \
+from mdxpy import DimensionProperty, Member, MdxTuple, MdxHierarchySet, normalize, MdxBuilder, CalculatedMember, MdxSet, \
     Order, ElementType, MdxLevelExpression
 
 
@@ -619,8 +619,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             "SELECT\r\n"
-            "NON EMPTY {[dim2].[dim2].[elem2]} ON 0,\r\n"
-            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY {[dim2].[dim2].[elem2]} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES MEMBER_NAME ON 1\r\n"
             "FROM [cube]\r\n"
             "WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])",
             mdx)
@@ -629,19 +629,20 @@ class Test(unittest.TestCase):
         mdx = MdxBuilder.from_cube("cube") \
             .rows_non_empty() \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_leaves("Dim1")) \
+            .add_properties_to_row_axis(DimensionProperty.of("Dim1", "Code and Name")) \
             .columns_non_empty() \
             .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of("Dim2", "Elem2"))) \
+            .add_properties_to_column_axis(DimensionProperty.of("Dim2", "Name")) \
             .where(Member.of("Dim3", "Elem3"), Member.of("Dim4", "Elem4")) \
-            .properties(SetAttribute.of("Dim3", "Code and Name"), SetAttribute.of("Dim4", "version")) \
             .to_mdx()
 
         self.assertEqual(
             "SELECT\r\n"
-            "NON EMPTY {[dim2].[dim2].[elem2]} ON 0,\r\n"
-            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY {[dim2].[dim2].[elem2]} DIMENSION PROPERTIES [dim2].[dim2].[name] ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} "
+            "DIMENSION PROPERTIES [dim1].[dim1].[codeandname] ON 1\r\n"
             "FROM [cube]\r\n"
-            "WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])\r\n"
-            "DIMENSION PROPERTIES [dim3].[dim3].[codeandname],[dim4].[dim4].[version]",
+            "WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])",
             mdx)
 
     def test_mdx_builder_tm1_ignore_bad_tuples(self):
@@ -656,8 +657,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             "SELECT\r\n"
-            "NON EMPTY TM1IGNORE_BADTUPLES {[dim2].[dim2].[elem2]} ON 0,\r\n"
-            "NON EMPTY TM1IGNORE_BADTUPLES {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY TM1IGNORE_BADTUPLES {[dim2].[dim2].[elem2]} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "NON EMPTY TM1IGNORE_BADTUPLES {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES MEMBER_NAME ON 1\r\n"
             "FROM [cube]\r\n"
             "WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])",
             mdx)
@@ -669,7 +670,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             "SELECT\r\n"
-            "{[dim1].[dim1].[elem1]} ON 0\r\n"
+            "{[dim1].[dim1].[elem1]} DIMENSION PROPERTIES MEMBER_NAME ON 0\r\n"
             "FROM [cube]",
             mdx)
 
@@ -684,11 +685,11 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             "SELECT\r\n"
-            "{[dim1].[dim1].[elem1]} ON 0,\r\n"
-            "{[dim2].[dim2].[elem2]} ON 1,\r\n"
-            "{[dim3].[dim3].[elem3]} ON 2,\r\n"
-            "{[dim4].[dim4].[elem4]} ON 3,\r\n"
-            "{[dim5].[dim5].[elem5]} ON 4\r\n"
+            "{[dim1].[dim1].[elem1]} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "{[dim2].[dim2].[elem2]} DIMENSION PROPERTIES MEMBER_NAME ON 1,\r\n"
+            "{[dim3].[dim3].[elem3]} DIMENSION PROPERTIES MEMBER_NAME ON 2,\r\n"
+            "{[dim4].[dim4].[elem4]} DIMENSION PROPERTIES MEMBER_NAME ON 3,\r\n"
+            "{[dim5].[dim5].[elem5]} DIMENSION PROPERTIES MEMBER_NAME ON 4\r\n"
             "FROM [cube]",
             mdx)
 
@@ -702,8 +703,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             "SELECT\r\n"
-            "NON EMPTY {[dim2].[dim2].[elem2]} ON 0,\r\n"
-            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY {[dim2].[dim2].[elem2]} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES MEMBER_NAME ON 1\r\n"
             "FROM [cube]",
             mdx)
 
@@ -745,8 +746,8 @@ class Test(unittest.TestCase):
             "MEMBER [period].[period].[avg2016] AS AVG({[period].[period].[2016].CHILDREN},"
             "[cube].([dim1].[dim1].[totaldim1],[dim2].[dim2].[totaldim2]))\r\n"
             "SELECT\r\n"
-            "NON EMPTY {([period].[period].[avg2016])} ON 0,\r\n"
-            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY {([period].[period].[avg2016])} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES MEMBER_NAME ON 1\r\n"
             "FROM [cube]\r\n"
             "WHERE ([dim2].[dim2].[totaldim2])",
             mdx)
@@ -766,7 +767,7 @@ class Test(unittest.TestCase):
             .columns_non_empty() \
             .add_member_tuple_to_columns(Member.of("Period", "AVG 2016")) \
             .where("[Dim2].[Total Dim2]") \
-            .properties("[Dim2].[Code and Name]") \
+            .add_properties_to_row_axis("[Dim1].[Code and Name]") \
             .to_mdx()
 
         self.assertEqual(
@@ -774,11 +775,10 @@ class Test(unittest.TestCase):
             "MEMBER [period].[period].[avg2016] AS AVG({[period].[period].[2016].CHILDREN},"
             "[cube].([dim1].[dim1].[totaldim1],[dim2].[dim2].[totaldim2]))\r\n"
             "SELECT\r\n"
-            "NON EMPTY {([period].[period].[avg2016])} ON 0,\r\n"
-            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY {([period].[period].[avg2016])} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES [dim1].[dim1].[codeandname] ON 1\r\n"
             "FROM [cube]\r\n"
-            "WHERE ([dim2].[dim2].[totaldim2])\r\n"
-            "DIMENSION PROPERTIES [dim2].[dim2].[codeandname]",
+            "WHERE ([dim2].[dim2].[totaldim2])",
             mdx)
 
     def test_mdx_build_with_multi_calculated_member(self):
@@ -815,8 +815,8 @@ class Test(unittest.TestCase):
             "MEMBER [period].[period].[sum2016] AS SUM({[period].[period].[2016].CHILDREN},"
             "[cube].([dim1].[dim1].[totaldim1],[dim2].[dim2].[totaldim2]))\r\n"
             "SELECT\r\n"
-            "NON EMPTY {[period].[period].[avg2016],[period].[period].[sum2016]} ON 0,\r\n"
-            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "NON EMPTY {[period].[period].[avg2016],[period].[period].[sum2016]} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES MEMBER_NAME ON 1\r\n"
             "FROM [cube]\r\n"
             "WHERE ([dim2].[dim2].[totaldim2])",
             mdx)
@@ -893,8 +893,8 @@ class Test(unittest.TestCase):
         self.assertEqual(
             mdx,
             "SELECT\r\n"
-            "{TM1SUBSETALL([dimension].[dimension])} ON 0,\r\n"
-            "{} ON 1\r\n"
+            "{TM1SUBSETALL([dimension].[dimension])} DIMENSION PROPERTIES MEMBER_NAME ON 0,\r\n"
+            "{} DIMENSION PROPERTIES MEMBER_NAME ON 1\r\n"
             "FROM [cube]")
 
     def test_add_empty_set_to_axis_error(self):

--- a/test.py
+++ b/test.py
@@ -924,14 +924,11 @@ class Test(unittest.TestCase):
     def test_level_expression_number(self):
         level = MdxLevelExpression.level_number(8, "Dimension1", "Hierarchy1")
         self.assertEqual("[dimension1].[hierarchy1].LEVELS(8)", level.to_mdx())
-        print(level.to_mdx())
 
     def test_level_expression_name(self):
         level = MdxLevelExpression.level_name('NamedLevel', "Dimension1", "Hierarchy1")
         self.assertEqual("[dimension1].[hierarchy1].LEVELS('NamedLevel')", level.to_mdx())
-        print(level.to_mdx())
 
     def test_level_expression_member_level(self):
         level = MdxLevelExpression.member_level(Member.of("Dimension1", "Hierarchy1", "Element1"))
         self.assertEqual("[dimension1].[hierarchy1].[element1].LEVEL", level.to_mdx())
-        print(level.to_mdx())

--- a/test.py
+++ b/test.py
@@ -2,7 +2,8 @@ import unittest
 
 import pytest
 
-from mdxpy import Member, MdxTuple, MdxHierarchySet, normalize, MdxBuilder, CalculatedMember, MdxSet, Order, ElementType, MdxLevelExpression
+from mdxpy import SetAttribute, Member, MdxTuple, MdxHierarchySet, normalize, MdxBuilder, CalculatedMember, MdxSet, \
+    Order, ElementType, MdxLevelExpression
 
 
 class Test(unittest.TestCase):
@@ -224,7 +225,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             "{ ([dimension1].[dimension1].[element1],[dimension2].[dimension2].[element3]),"
-            "([dimension1].[dimension1].[element2],[dimension2].[dimension2].[element2])," 
+            "([dimension1].[dimension1].[element2],[dimension2].[dimension2].[element2]),"
             "([dimension1].[dimension1].[element3],[dimension2].[dimension2].[element1]) }",
             mdx_set.to_mdx())
 
@@ -452,8 +453,8 @@ class Test(unittest.TestCase):
         member = Member.of('Dimension', 'Hierarchy', 'Member1')
         hierarchy_set = MdxHierarchySet.descendants(member,
                                                     MdxLevelExpression.level_number(2,
-                                                                                  'Dimension',
-                                                                                  'Hierarchy'),
+                                                                                    'Dimension',
+                                                                                    'Hierarchy'),
                                                     desc_flag='SELF_AND_BEFORE')
         self.assertEqual("{DESCENDANTS([dimension].[hierarchy].[member1], "
                          "[dimension].[hierarchy].LEVELS(2), "
@@ -624,6 +625,25 @@ class Test(unittest.TestCase):
             "WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])",
             mdx)
 
+    def test_mdx_builder_simple_properties(self):
+        mdx = MdxBuilder.from_cube("cube") \
+            .rows_non_empty() \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_leaves("Dim1")) \
+            .columns_non_empty() \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of("Dim2", "Elem2"))) \
+            .where(Member.of("Dim3", "Elem3"), Member.of("Dim4", "Elem4")) \
+            .properties(SetAttribute.of("Dim3", "Code and Name"), SetAttribute.of("Dim4", "version")) \
+            .to_mdx()
+
+        self.assertEqual(
+            "SELECT\r\n"
+            "NON EMPTY {[dim2].[dim2].[elem2]} ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "FROM [cube]\r\n"
+            "WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])\r\n"
+            "DIMENSION PROPERTIES [dim3].[dim3].[codeandname],[dim4].[dim4].[version]",
+            mdx)
+
     def test_mdx_builder_tm1_ignore_bad_tuples(self):
         mdx = MdxBuilder.from_cube("cube") \
             .tm1_ignore_bad_tuples() \
@@ -729,6 +749,36 @@ class Test(unittest.TestCase):
             "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
             "FROM [cube]\r\n"
             "WHERE ([dim2].[dim2].[totaldim2])",
+            mdx)
+
+    def test_mdx_builder_with_calculated_member_with_properties(self):
+        mdx = MdxBuilder.from_cube(cube="Cube").with_member(
+            CalculatedMember.avg(
+                dimension="Period",
+                hierarchy="Period",
+                element="AVG 2016",
+                cube="Cube",
+                mdx_set=MdxHierarchySet.children(member=Member.of("Period", "2016")),
+                mdx_tuple=MdxTuple.of(Member.of("Dim1", "Total Dim1"),
+                                      Member.of("Dim2", "Total Dim2")))) \
+            .rows_non_empty() \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_leaves("dim1", "dim1")) \
+            .columns_non_empty() \
+            .add_member_tuple_to_columns(Member.of("Period", "AVG 2016")) \
+            .where("[Dim2].[Total Dim2]") \
+            .properties("[Dim2].[Code and Name]") \
+            .to_mdx()
+
+        self.assertEqual(
+            "WITH\r\n"
+            "MEMBER [period].[period].[avg2016] AS AVG({[period].[period].[2016].CHILDREN},"
+            "[cube].([dim1].[dim1].[totaldim1],[dim2].[dim2].[totaldim2]))\r\n"
+            "SELECT\r\n"
+            "NON EMPTY {([period].[period].[avg2016])} ON 0,\r\n"
+            "NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1\r\n"
+            "FROM [cube]\r\n"
+            "WHERE ([dim2].[dim2].[totaldim2])\r\n"
+            "DIMENSION PROPERTIES [dim2].[dim2].[codeandname]",
             mdx)
 
     def test_mdx_build_with_multi_calculated_member(self):


### PR DESCRIPTION
Fixes #18, Sucessor of #34 

Allows dimension properties per axis. Sample:

``` python
from TM1py import TM1Service

from mdxpy import MdxBuilder, MdxHierarchySet, Member, DimensionProperty

with TM1Service(address='localhost', port=12354, ssl=True, user="admin", password="apple") as tm1:
    query = MdxBuilder.from_cube("c1")
    query.add_hierarchy_set_to_row_axis(MdxHierarchySet.all_leaves("d1", "d1"))
    query.add_properties_to_row_axis(DimensionProperty("d1", "d1", "Description"))
    query.rows_non_empty()
    query.add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of("d2", "e1")))
    query.columns_non_empty()

    print(query.to_mdx())

    df = tm1.cells.execute_mdx_dataframe(mdx=query.to_mdx(), include_attributes=True)
    print(df.head(4).to_markdown())

```

> Output

```
SELECT
NON EMPTY {[d2].[d2].[e1]} DIMENSION PROPERTIES MEMBER_NAME ON 0,
NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([d1].[d1])},0)} DIMENSION PROPERTIES [d1].[d1].[description] ON 1
FROM [c1]
```

|    | d1   | Description   | d2   |   Value |
|---:|:-----|:--------------|:-----|--------:|
|  0 | e1   | a1            | e1   |       1 |
|  1 | e2   | a2            | e1   |       2 |
|  2 | e3   | a3            | e1   |       3 |
|  3 | e4   | a4            | e1   |      10 |
