### PR TITLE
Add head and skip_dimension_properties in to_mdx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ DESCRIPTION = open('readme.md').read()
 
 setup(
     name="mdxpy",
-    version='1.2',
+    version='1.3',
     maintainer='Marius Wirtz',
     maintainer_email='MWirtz@cubewise.com',
     license="MIT-LICENSE",


### PR DESCRIPTION
Allow to pass `head_rows`, `tail_rows`, `head_columns`, `tail_columns` and `skip_dimension_properties` arguments to the `to_mdx` function on the `MdxBuilder` class.

`head` and `tail` arguments will be applied to each axis. 
One useful application of this feature is that any arbitrary query can be reduced to one cell _(or n cells)_ when generating the query string out of the MdxBuilder.

``` python
        mdx = MdxBuilder.from_cube("cube") \
            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_leaves("Dim1")) \
            .columns_non_empty() \
            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of("Dim2", "Elem2"))) \
            .where(Member.of("Dim3", "Elem3"), Member.of("Dim4", "Elem4")) \
            .to_mdx(head_columns=1)
```

``` SQL
SELECT
NON EMPTY {HEAD({TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} * {[dim2].[dim2].[elem2]}, 1)}
DIMENSION PROPERTIES MEMBER_NAME ON 0
FROM [cube]
WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])
```