### PR TITLE
Feature/multiple mdx builder

### DIFF
--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -1328,8 +1328,6 @@ class MultiMdxBuilder(MdxBuilder):
                skip_dimension_properties: bool = False) -> List[str]:
         mdx_list = []
         for axes_index, axes in enumerate(self.axes_list):
-            print(axes_index)
-            print(axes)
             mdx_with = "WITH\r\n" + "\r\n".join(
                 calculated_member.to_mdx()
                 for calculated_member


### PR DESCRIPTION
A new class has been added to create a list of mdx queries using the same syntax as in MdxBuilder. It may be useful for breaking up the mdx query into smaller mdx subqueires and running them in parallel.