### PR TITLE
Add drilldown hierarchy with levels

### DIFF
--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -462,7 +462,7 @@ class MdxHierarchySet(MdxSet):
         return AncestorHierarchySet(member, ancestor)
 
     @staticmethod
-    def drill_down_level(member: Union[str, Member], level) -> 'MdxHierarchySet':
+    def drill_down_level(member: Union[str, Member], level: int) -> 'MdxHierarchySet':
         if isinstance(member, str):
             member = Member.of(member)
         return DrillDownLevelHierarchySet(member, level)
@@ -704,6 +704,11 @@ class DrillDownLevelHierarchySet(MdxHierarchySet):
         super(DrillDownLevelHierarchySet, self).__init__(member.dimension, member.hierarchy)
         self.level = level
         self.member = member
+
+        if level:
+            self.level = level
+        else:
+            self.level = 1
 
     def to_mdx(self) -> str:
         startstring = ''

--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -462,10 +462,10 @@ class MdxHierarchySet(MdxSet):
         return AncestorHierarchySet(member, ancestor)
 
     @staticmethod
-    def drill_down_level(member: Union[str, Member]) -> 'MdxHierarchySet':
+    def drill_down_level(member: Union[str, Member], level) -> 'MdxHierarchySet':
         if isinstance(member, str):
             member = Member.of(member)
-        return DrillDownLevelHierarchySet(member)
+        return DrillDownLevelHierarchySet(member, level)
 
     @staticmethod
     def descendants(member: Union[str, Member], level_or_depth: Union[MdxLevelExpression, int] = None,
@@ -700,12 +700,19 @@ class Tm1DrillDownMemberSet(MdxHierarchySet):
 
 class DrillDownLevelHierarchySet(MdxHierarchySet):
 
-    def __init__(self, member: Member):
+    def __init__(self, member: Member, level):
         super(DrillDownLevelHierarchySet, self).__init__(member.dimension, member.hierarchy)
+        self.level = level
         self.member = member
 
     def to_mdx(self) -> str:
-        return f"{{DRILLDOWNLEVEL({{{self.member.unique_name}}})}}"
+        startstring = ''
+        endstring = ''
+        for _ in range(self.level):
+            startstring += 'DRILLDOWNLEVEL('
+            endstring += ')'
+            
+        return f"{{{startstring}{{{self.member.unique_name}}}{endstring}}}"
 
 
 class DescendantsHierarchySet(MdxHierarchySet):

--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -702,7 +702,6 @@ class DrillDownLevelHierarchySet(MdxHierarchySet):
 
     def __init__(self, member: Member, level):
         super(DrillDownLevelHierarchySet, self).__init__(member.dimension, member.hierarchy)
-        self.level = level
         self.member = member
 
         if level:

--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -700,14 +700,10 @@ class Tm1DrillDownMemberSet(MdxHierarchySet):
 
 class DrillDownLevelHierarchySet(MdxHierarchySet):
 
-    def __init__(self, member: Member, level):
+    def __init__(self, member: Member, level: int =1):
         super(DrillDownLevelHierarchySet, self).__init__(member.dimension, member.hierarchy)
         self.member = member
-
-        if level:
-            self.level = level
-        else:
-            self.level = 1
+        self.level = level
 
     def to_mdx(self) -> str:
         startstring = ''

--- a/test.py
+++ b/test.py
@@ -279,6 +279,13 @@ class Test(unittest.TestCase):
             "{DRILLDOWNLEVEL({[dimension].[dimension].[element]})}",
             hierarchy_set.to_mdx())
 
+        hierarchy_set = MdxHierarchySet.drill_down_level(Member.of("Dimension", "Element"), level=3)
+
+        self.assertEqual(
+            "{DRILLDOWNLEVEL(DRILLDOWNLEVEL(DRILLDOWNLEVEL({[dimension].[dimension].[element]})))}",
+            hierarchy_set.to_mdx())
+
+
     def test_mdx_hierarchy_set_tm1_drill_down_member_all_recursive(self):
         hierarchy_set = MdxHierarchySet.members([Member.of("dimension", "element")]).tm1_drill_down_member(
             recursive=True)

--- a/test.py
+++ b/test.py
@@ -273,7 +273,7 @@ class Test(unittest.TestCase):
             hierarchy_set.to_mdx())
 
     def test_mdx_hierarchy_set_drill_down_level(self):
-        hierarchy_set = MdxHierarchySet.drill_down_level(Member.of("Dimension", "Element"))
+        hierarchy_set = MdxHierarchySet.drill_down_level(Member.of("Dimension", "Element"), level=1)
 
         self.assertEqual(
             "{DRILLDOWNLEVEL({[dimension].[dimension].[element]})}",


### PR DESCRIPTION
Hi @MariusWirtz 

have added drilldown with level, so we can drilldown based on levels. Lets suppose level 2/3/4 depending on requirement.Right now we can only drilldown once or recursive all.

Let me know your views.

thanks
vish